### PR TITLE
Add self sg ingress rule option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [linkedin](http
 | description | The description of the all resources. | `string` | `"Managed by Terraform"` | no |
 | engine\_version | The version number of the cache engine to be used for the cache clusters in this replication group. | `string` | `"5.0.6"` | no |
 | family | The family of the ElastiCache parameter group. | `string` | `"redis5.0"` | no |
+| ingress\_self | Specify whether the security group itself will be added as a source to the ingress rule. | `bool` | `false` | no |
 | ingress\_cidr\_blocks | List of Ingress CIDR blocks. | `list(string)` | `[]` | no |
 | kms\_key\_id | The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true` | `string` | `""` | no |
 | maintenance\_window | Specifies the weekly time range for when maintenance on the cache cluster is performed. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,17 @@ resource "aws_security_group" "redis" {
   }
 }
 
+resource "aws_security_group_rule" "redis_ingress_self" {
+  count = var.ingress_self ? 1 : 0
+
+  type              = "ingress"
+  from_port         = var.port
+  to_port           = var.port
+  protocol          = "tcp"
+  self              = true
+  security_group_id = aws_security_group.redis.id
+}
+
 resource "aws_security_group_rule" "redis_ingress_cidr_blocks" {
   count = length(var.ingress_cidr_blocks) != 0 ? 1 : 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "ingress_cidr_blocks" {
   default     = []
 }
 
+variable "ingress_self" {
+  type        = bool
+  description = "Specify whether the security group itself will be added as a source to the ingress rule."
+  default     = false
+}
+
 variable "security_group_ids" {
   type        = list(string)
   description = "List of Security Groups."


### PR DESCRIPTION
# Description

Similar to the `ingress_cidr_blocks`, this allows users to configure the Redis security group to only allow access from itself.