### PR TITLE
Added ability to enable the prevent destroy option on the redis cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [linkedin](http
 | number\_cache\_clusters | The number of cache clusters (primary and replicas) this replication group will have. | `number` | n/a | yes |
 | parameter | A list of Redis parameters to apply. Note that parameters may differ from one Redis family to another | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | port | The port number on which each of the cache nodes will accept connections. | `number` | `6379` | no |
+| prevent_destroy | Controls the lifecycle policy which can prevent the redis cluster from being destroyed on subsequent applies | `boolean` | `false` | no |
 | replicas\_per\_node\_group | Required when `cluster_mode_enabled` is set to true. Specify the number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will force a new resource. | `number` | `0` | no |
 | security\_group\_ids | List of Security Groups. | `list(string)` | `[]` | no |
 | snapshot\_retention\_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | `number` | `30` | no |

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,10 @@ resource "aws_elasticache_replication_group" "redis" {
 
   notification_topic_arn = var.notification_topic_arn
 
+  lifecycle {
+    prevent_destroy = var.prevent_destroy
+  }
+
   dynamic "cluster_mode" {
     for_each = var.cluster_mode_enabled ? [1] : []
     content {
@@ -126,4 +130,3 @@ resource "aws_security_group_rule" "redis_egress" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.redis.id
 }
-

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
-resource "aws_elasticache_replication_group" "redis" {
+resource "aws_elasticache_replication_group" "redis_no_destroy" {
+  count = var.prevent_destroy == "true" ? 1 : 0
+
   engine = "redis"
 
   parameter_group_name = aws_elasticache_parameter_group.redis.name
@@ -33,7 +35,62 @@ resource "aws_elasticache_replication_group" "redis" {
   notification_topic_arn = var.notification_topic_arn
 
   lifecycle {
-    prevent_destroy = var.prevent_destroy
+    prevent_destroy = true
+  }
+
+  dynamic "cluster_mode" {
+    for_each = var.cluster_mode_enabled ? [1] : []
+    content {
+      replicas_per_node_group = var.replicas_per_node_group
+      num_node_groups         = var.num_node_groups
+    }
+  }
+
+  tags = merge(
+    {
+      "Name" = "${var.name_prefix}-redis"
+    },
+    var.tags,
+  )
+}
+
+resource "aws_elasticache_replication_group" "redis" {
+  count  = var.prevent_destroy == "false" ? 0 : 1
+  engine = "redis"
+
+  parameter_group_name = aws_elasticache_parameter_group.redis.name
+  subnet_group_name    = aws_elasticache_subnet_group.redis.name
+  security_group_ids   = concat(var.security_group_ids, [aws_security_group.redis.id])
+
+  availability_zones    = var.availability_zones
+  replication_group_id  = "${var.name_prefix}-redis"
+  number_cache_clusters = var.cluster_mode_enabled ? null : var.number_cache_clusters
+  node_type             = var.node_type
+
+  engine_version = var.engine_version
+  port           = var.port
+
+  maintenance_window         = var.maintenance_window
+  snapshot_window            = var.snapshot_window
+  snapshot_retention_limit   = var.snapshot_retention_limit
+  final_snapshot_identifier  = var.final_snapshot_identifier
+  automatic_failover_enabled = var.automatic_failover_enabled && var.number_cache_clusters > 1 ? true : false
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
+  multi_az_enabled           = var.multi_az_enabled
+
+  at_rest_encryption_enabled = var.at_rest_encryption_enabled
+  transit_encryption_enabled = var.transit_encryption_enabled
+  auth_token                 = var.auth_token != "" ? var.auth_token : null
+  kms_key_id                 = var.kms_key_id
+
+  apply_immediately = var.apply_immediately
+
+  replication_group_description = var.description
+
+  notification_topic_arn = var.notification_topic_arn
+
+  lifecycle {
+    prevent_destroy = false
   }
 
   dynamic "cluster_mode" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,25 +1,33 @@
 output "elasticache_replication_group_arn" {
-  value       = aws_elasticache_replication_group.redis.arn
+  value       = var.prevent_destroy ? aws_elasticache_replication_group.redis_no_destroy[0].arn : aws_elasticache_replication_group.redis[0].arn
   description = "The Amazon Resource Name (ARN) of the created ElastiCache Replication Group."
 }
 
 output "elasticache_replication_group_id" {
-  value       = aws_elasticache_replication_group.redis.id
+  value       = var.prevent_destroy ? aws_elasticache_replication_group.redis_no_destroy[0].id : aws_elasticache_replication_group.redis[0].id
   description = "The ID of the ElastiCache Replication Group."
 }
 
 output "elasticache_replication_group_primary_endpoint_address" {
-  value       = var.cluster_mode_enabled ? aws_elasticache_replication_group.redis.configuration_endpoint_address : aws_elasticache_replication_group.redis.primary_endpoint_address
+  value = var.cluster_mode_enabled ? (
+    var.prevent_destroy ? aws_elasticache_replication_group.redis_no_destroy[0].configuration_endpoint_address : aws_elasticache_replication_group.redis[0].configuration_endpoint_address
+    ) : (
+    var.prevent_destroy ? aws_elasticache_replication_group.redis_no_destroy[0].primary_endpoint_address : aws_elasticache_replication_group.redis[0].primary_endpoint_address
+  )
   description = "The address of the endpoint for the primary node in the replication group."
 }
 
 output "elasticache_replication_group_reader_endpoint_address" {
-  value       = var.cluster_mode_enabled ? aws_elasticache_replication_group.redis.configuration_endpoint_address : aws_elasticache_replication_group.redis.reader_endpoint_address
+  value = var.cluster_mode_enabled ? (
+    var.prevent_destroy ? aws_elasticache_replication_group.redis_no_destroy[0].configuration_endpoint_address : aws_elasticache_replication_group.redis[0].configuration_endpoint_address
+    ) : (
+    var.prevent_destroy ? aws_elasticache_replication_group.redis_no_destroy[0].reader_endpoint_address : aws_elasticache_replication_group.redis[0].reader_endpoint_address
+  )
   description = "The address of the endpoint for the reader node in the replication group."
 }
 
 output "elasticache_replication_group_member_clusters" {
-  value       = aws_elasticache_replication_group.redis.member_clusters
+  value       = var.prevent_destroy ? aws_elasticache_replication_group.redis_no_destroy[0].member_clusters : aws_elasticache_replication_group.redis[0].member_clusters
   description = "The identifiers of all the nodes that are part of this replication group."
 }
 
@@ -70,10 +78,10 @@ output "security_group_egress" {
 
 output "elasticache_auth_token" {
   description = "The Redis Auth Token."
-  value       = aws_elasticache_replication_group.redis.auth_token
+  value       = var.prevent_destroy ? aws_elasticache_replication_group.redis_no_destroy[0].auth_token : aws_elasticache_replication_group.redis[0].auth_token
 }
 
 output "elasticache_port" {
   description = "The Redis port."
-  value       = aws_elasticache_replication_group.redis.port
+  value       = var.prevent_destroy ? aws_elasticache_replication_group.redis_no_destroy[0].port : aws_elasticache_replication_group.redis[0].port
 }

--- a/variables.tf
+++ b/variables.tf
@@ -180,3 +180,9 @@ variable "final_snapshot_identifier" {
   description = "The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made."
   default     = null
 }
+
+variable "prevent_destroy" {
+  type        = bool
+  description = "Prevents the destruction of the Redis cluster when true"
+  default     = false
+}


### PR DESCRIPTION
# Description

Added the lifecycle block to the redis cluster to allow the option to enable prevent_destroy. It is set to false by default