### PR TITLE
Terraform 0.15 support by marking outputs as sensitive

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.45.0
+  rev: v1.48.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-<a name="unreleased"></a>
-## [Unreleased]
+<a name="2.0.0"></a>
+## [2.0.0] - 2021-04-19
 
-- Update README.md
+- Add support for Terraform 0.15 by setting sensitive outputs to have the sensitive = true flag. (https://www.terraform.io/upgrade-guides/0-15.html#sensitive-output-values)
+- Terraform version requirement bumped to 0.14.5 in order to support sensitive values
 
 
 <a name="1.4.0"></a>
@@ -72,7 +73,7 @@ All notable changes to this project will be documented in this file.
 - Initial commit of docs
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/1.4.0...HEAD
+[2.0.0]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/1.4.0...2.0.0
 [1.4.0]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/1.3.1...1.4.0
 [1.3.1]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/1.2.0...1.3.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A Terraform module to create an AWS Redis ElastiCache cluster
 
 ## Terraform versions
 
-Terraform 0.12. Pin module version to `~> v1.0`. Submit pull-requests to `master` branch.
+Terraform 0.14.5. Pin module version to `~> v2.0`.
+Terraform 0.12 - 0.14.4. Pin module version to `~> v1.0`.
+Submit pull-requests to `master` branch.
 
 ## Usage
 
@@ -55,7 +57,8 @@ module "redis" {
 
 ## Assumptions
 
-Module is to be used with Terraform > 0.12.
+Module v1.0 is to be used with Terraform > 0.12
+Module v2.0+ is to be used with Terraform > 0.14.5
 
 ## Examples
 
@@ -71,74 +74,90 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [linkedin](http
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
-| aws | >= 3.26 |
-| random | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.26 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.26 |
-| random | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.26 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_elasticache_parameter_group.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_parameter_group) | resource |
+| [aws_elasticache_replication_group.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group) | resource |
+| [aws_elasticache_subnet_group.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
+| [aws_security_group.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.redis_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.redis_ingress_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.redis_ingress_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [random_id.redis_pg](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| apply\_immediately | Specifies whether any modifications are applied immediately, or during the next maintenance window. | `bool` | `false` | no |
-| at\_rest\_encryption\_enabled | Whether to enable encryption at rest. | `bool` | `true` | no |
-| auth\_token | The password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true`. | `string` | `""` | no |
-| auto\_minor\_version\_upgrade | n/a | `string` | `true` | no |
-| automatic\_failover\_enabled | Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. | `bool` | `true` | no |
-| availability\_zones | A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important. | `list(string)` | `null` | no |
-| cluster\_mode\_enabled | Enable creation of a native redis cluster. | `bool` | `false` | no |
-| description | The description of the all resources. | `string` | `"Managed by Terraform"` | no |
-| engine\_version | The version number of the cache engine to be used for the cache clusters in this replication group. | `string` | `"5.0.6"` | no |
-| family | The family of the ElastiCache parameter group. | `string` | `"redis5.0"` | no |
-| final\_snapshot\_identifier | The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made. | `string` | `null` | no |
-| ingress\_cidr\_blocks | List of Ingress CIDR blocks. | `list(string)` | `[]` | no |
-| ingress\_self | Specify whether the security group itself will be added as a source to the ingress rule. | `bool` | `false` | no |
-| kms\_key\_id | The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true` | `string` | `""` | no |
-| maintenance\_window | Specifies the weekly time range for when maintenance on the cache cluster is performed. | `string` | `""` | no |
-| multi\_az\_enabled | Specifies whether to enable Multi-AZ Support for the replication group. If true, `automatic_failover_enabled` must also be enabled. Defaults to false. | `string` | `null` | no |
-| name\_prefix | The replication group identifier. This parameter is stored as a lowercase string. | `string` | n/a | yes |
-| node\_type | The compute and memory capacity of the nodes in the node group. | `string` | n/a | yes |
-| notification\_topic\_arn | An Amazon Resource Name (ARN) of an SNS topic to send ElastiCache notifications to. Example: `arn:aws:sns:us-east-1:012345678999:my_sns_topic` | `string` | `""` | no |
-| num\_node\_groups | Required when `cluster_mode_enabled` is set to true. Specify the number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications. | `number` | `0` | no |
-| number\_cache\_clusters | The number of cache clusters (primary and replicas) this replication group will have. | `number` | n/a | yes |
-| parameter | A list of Redis parameters to apply. Note that parameters may differ from one Redis family to another | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
-| port | The port number on which each of the cache nodes will accept connections. | `number` | `6379` | no |
-| replicas\_per\_node\_group | Required when `cluster_mode_enabled` is set to true. Specify the number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will force a new resource. | `number` | `0` | no |
-| security\_group\_ids | List of Security Groups. | `list(string)` | `[]` | no |
-| snapshot\_retention\_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | `number` | `30` | no |
-| snapshot\_window | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. | `string` | `""` | no |
-| subnet\_ids | List of VPC Subnet IDs for the cache subnet group. | `list(string)` | n/a | yes |
-| tags | A mapping of tags to assign to all resources. | `map(string)` | `{}` | no |
-| transit\_encryption\_enabled | Whether to enable encryption in transit. | `bool` | `true` | no |
-| vpc\_id | VPC Id to associate with Redis ElastiCache. | `string` | n/a | yes |
+| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any modifications are applied immediately, or during the next maintenance window. | `bool` | `false` | no |
+| <a name="input_at_rest_encryption_enabled"></a> [at\_rest\_encryption\_enabled](#input\_at\_rest\_encryption\_enabled) | Whether to enable encryption at rest. | `bool` | `true` | no |
+| <a name="input_auth_token"></a> [auth\_token](#input\_auth\_token) | The password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true`. | `string` | `""` | no |
+| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | n/a | `string` | `true` | no |
+| <a name="input_automatic_failover_enabled"></a> [automatic\_failover\_enabled](#input\_automatic\_failover\_enabled) | Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. | `bool` | `true` | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important. | `list(string)` | `null` | no |
+| <a name="input_cluster_mode_enabled"></a> [cluster\_mode\_enabled](#input\_cluster\_mode\_enabled) | Enable creation of a native redis cluster. | `bool` | `false` | no |
+| <a name="input_description"></a> [description](#input\_description) | The description of the all resources. | `string` | `"Managed by Terraform"` | no |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The version number of the cache engine to be used for the cache clusters in this replication group. | `string` | `"5.0.6"` | no |
+| <a name="input_family"></a> [family](#input\_family) | The family of the ElastiCache parameter group. | `string` | `"redis5.0"` | no |
+| <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made. | `string` | `null` | no |
+| <a name="input_ingress_cidr_blocks"></a> [ingress\_cidr\_blocks](#input\_ingress\_cidr\_blocks) | List of Ingress CIDR blocks. | `list(string)` | `[]` | no |
+| <a name="input_ingress_self"></a> [ingress\_self](#input\_ingress\_self) | Specify whether the security group itself will be added as a source to the ingress rule. | `bool` | `false` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true` | `string` | `""` | no |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | Specifies the weekly time range for when maintenance on the cache cluster is performed. | `string` | `""` | no |
+| <a name="input_multi_az_enabled"></a> [multi\_az\_enabled](#input\_multi\_az\_enabled) | Specifies whether to enable Multi-AZ Support for the replication group. If true, `automatic_failover_enabled` must also be enabled. Defaults to false. | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The replication group identifier. This parameter is stored as a lowercase string. | `string` | n/a | yes |
+| <a name="input_node_type"></a> [node\_type](#input\_node\_type) | The compute and memory capacity of the nodes in the node group. | `string` | n/a | yes |
+| <a name="input_notification_topic_arn"></a> [notification\_topic\_arn](#input\_notification\_topic\_arn) | An Amazon Resource Name (ARN) of an SNS topic to send ElastiCache notifications to. Example: `arn:aws:sns:us-east-1:012345678999:my_sns_topic` | `string` | `""` | no |
+| <a name="input_num_node_groups"></a> [num\_node\_groups](#input\_num\_node\_groups) | Required when `cluster_mode_enabled` is set to true. Specify the number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications. | `number` | `0` | no |
+| <a name="input_number_cache_clusters"></a> [number\_cache\_clusters](#input\_number\_cache\_clusters) | The number of cache clusters (primary and replicas) this replication group will have. | `number` | n/a | yes |
+| <a name="input_parameter"></a> [parameter](#input\_parameter) | A list of Redis parameters to apply. Note that parameters may differ from one Redis family to another | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
+| <a name="input_port"></a> [port](#input\_port) | The port number on which each of the cache nodes will accept connections. | `number` | `6379` | no |
+| <a name="input_replicas_per_node_group"></a> [replicas\_per\_node\_group](#input\_replicas\_per\_node\_group) | Required when `cluster_mode_enabled` is set to true. Specify the number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will force a new resource. | `number` | `0` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of Security Groups. | `list(string)` | `[]` | no |
+| <a name="input_snapshot_retention_limit"></a> [snapshot\_retention\_limit](#input\_snapshot\_retention\_limit) | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | `number` | `30` | no |
+| <a name="input_snapshot_window"></a> [snapshot\_window](#input\_snapshot\_window) | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. | `string` | `""` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of VPC Subnet IDs for the cache subnet group. | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources. | `map(string)` | `{}` | no |
+| <a name="input_transit_encryption_enabled"></a> [transit\_encryption\_enabled](#input\_transit\_encryption\_enabled) | Whether to enable encryption in transit. | `bool` | `true` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC Id to associate with Redis ElastiCache. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| elasticache\_auth\_token | The Redis Auth Token. |
-| elasticache\_parameter\_group\_id | The ElastiCache parameter group name. |
-| elasticache\_port | The Redis port. |
-| elasticache\_replication\_group\_arn | The Amazon Resource Name (ARN) of the created ElastiCache Replication Group. |
-| elasticache\_replication\_group\_id | The ID of the ElastiCache Replication Group. |
-| elasticache\_replication\_group\_member\_clusters | The identifiers of all the nodes that are part of this replication group. |
-| elasticache\_replication\_group\_primary\_endpoint\_address | The address of the endpoint for the primary node in the replication group. |
-| elasticache\_replication\_group\_reader\_endpoint\_address | The address of the endpoint for the reader node in the replication group. |
-| security\_group\_arn | The ARN of the Redis ElastiCache security group. |
-| security\_group\_description | The description of the Redis ElastiCache security group. |
-| security\_group\_egress | The egress rules of the Redis ElastiCache security group. |
-| security\_group\_id | The ID of the Redis ElastiCache security group. |
-| security\_group\_ingress | The ingress rules of the Redis ElastiCache security group. |
-| security\_group\_name | The name of the Redis ElastiCache security group. |
-| security\_group\_owner\_id | The owner ID of the Redis ElastiCache security group. |
-| security\_group\_vpc\_id | The VPC ID of the Redis ElastiCache security group. |
-
+| <a name="output_elasticache_auth_token"></a> [elasticache\_auth\_token](#output\_elasticache\_auth\_token) | The Redis Auth Token. |
+| <a name="output_elasticache_parameter_group_id"></a> [elasticache\_parameter\_group\_id](#output\_elasticache\_parameter\_group\_id) | The ElastiCache parameter group name. |
+| <a name="output_elasticache_port"></a> [elasticache\_port](#output\_elasticache\_port) | The Redis port. |
+| <a name="output_elasticache_replication_group_arn"></a> [elasticache\_replication\_group\_arn](#output\_elasticache\_replication\_group\_arn) | The Amazon Resource Name (ARN) of the created ElastiCache Replication Group. |
+| <a name="output_elasticache_replication_group_id"></a> [elasticache\_replication\_group\_id](#output\_elasticache\_replication\_group\_id) | The ID of the ElastiCache Replication Group. |
+| <a name="output_elasticache_replication_group_member_clusters"></a> [elasticache\_replication\_group\_member\_clusters](#output\_elasticache\_replication\_group\_member\_clusters) | The identifiers of all the nodes that are part of this replication group. |
+| <a name="output_elasticache_replication_group_primary_endpoint_address"></a> [elasticache\_replication\_group\_primary\_endpoint\_address](#output\_elasticache\_replication\_group\_primary\_endpoint\_address) | The address of the endpoint for the primary node in the replication group. |
+| <a name="output_elasticache_replication_group_reader_endpoint_address"></a> [elasticache\_replication\_group\_reader\_endpoint\_address](#output\_elasticache\_replication\_group\_reader\_endpoint\_address) | The address of the endpoint for the reader node in the replication group. |
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the Redis ElastiCache security group. |
+| <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the Redis ElastiCache security group. |
+| <a name="output_security_group_egress"></a> [security\_group\_egress](#output\_security\_group\_egress) | The egress rules of the Redis ElastiCache security group. |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the Redis ElastiCache security group. |
+| <a name="output_security_group_ingress"></a> [security\_group\_ingress](#output\_security\_group\_ingress) | The ingress rules of the Redis ElastiCache security group. |
+| <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the Redis ElastiCache security group. |
+| <a name="output_security_group_owner_id"></a> [security\_group\_owner\_id](#output\_security\_group\_owner\_id) | The owner ID of the Redis ElastiCache security group. |
+| <a name="output_security_group_vpc_id"></a> [security\_group\_vpc\_id](#output\_security\_group\_vpc\_id) | The VPC ID of the Redis ElastiCache security group. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/outputs.tf
+++ b/outputs.tf
@@ -71,6 +71,7 @@ output "security_group_egress" {
 output "elasticache_auth_token" {
   description = "The Redis Auth Token."
   value       = aws_elasticache_replication_group.redis.auth_token
+  sensitive   = true
 }
 
 output "elasticache_port" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.14.5"
 
   required_providers {
     aws    = ">= 3.26"
-    random = ">= 3.0"
+    random = ">= 3.1.0"
   }
 }


### PR DESCRIPTION
# Description

Support for Terraform 0.15 by marking outputs as sensitive.
Bumped minimum Terraform version supported to 0.14.5.