### PR TITLE
Add support for global_replication_group_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ No modules.
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The version number of the cache engine to be used for the cache clusters in this replication group. | `string` | `"5.0.6"` | no |
 | <a name="input_family"></a> [family](#input\_family) | The family of the ElastiCache parameter group. | `string` | `"redis5.0"` | no |
 | <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made. | `string` | `null` | no |
+| <a name="input_global_replication_group_id"></a> [global\_replication\_group\_id](#input\_global\_replication\_group\_id) | The ID of the global replication group to which this replication group should belong. | `string` | `null` | no |
 | <a name="input_ingress_cidr_blocks"></a> [ingress\_cidr\_blocks](#input\_ingress\_cidr\_blocks) | List of Ingress CIDR blocks. | `list(string)` | `[]` | no |
 | <a name="input_ingress_self"></a> [ingress\_self](#input\_ingress\_self) | Specify whether the security group itself will be added as a source to the ingress rule. | `bool` | `false` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true` | `string` | `""` | no |

--- a/examples/redis-replication-group/main.tf
+++ b/examples/redis-replication-group/main.tf
@@ -37,7 +37,7 @@ data "aws_subnet_ids" "replica" {
 module "redis_main" {
   source = "../../"
 
-  name_prefix           = "redis-replication-group-example"
+  name_prefix           = "redis-replication-example"
   number_cache_clusters = 2
   node_type             = "cache.m5.large"
   auth_token            = "1234567890asdfghjkl"

--- a/examples/redis-replication-group/main.tf
+++ b/examples/redis-replication-group/main.tf
@@ -1,0 +1,68 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "replica"
+}
+
+#####
+# VPC and subnets
+#####
+
+data "aws_vpc" "main" {
+  default = true
+}
+
+data "aws_vpc" "replica" {
+  default = true
+
+  provider = aws.replica
+}
+
+data "aws_subnet_ids" "main" {
+  vpc_id = data.aws_vpc.main.id
+}
+
+data "aws_subnet_ids" "replica" {
+  vpc_id = data.aws_vpc.replica.id
+
+  provider = aws.replica
+}
+#####
+# Elasticache Redis
+#####
+
+module "redis_main" {
+  source = "../../"
+
+  name_prefix           = "redis-replication-group-example"
+  number_cache_clusters = 2
+  node_type             = "cache.m5.large"
+  auth_token            = "1234567890asdfghjkl"
+
+  subnet_ids = data.aws_subnet_ids.main.ids
+  vpc_id     = data.aws_vpc.main.id
+}
+
+resource "aws_elasticache_global_replication_group" "this" {
+  global_replication_group_id_suffix = "ha"
+  primary_replication_group_id       = module.redis_main.elasticache_replication_group_id
+}
+
+module "redis_replica" {
+  source = "../../"
+
+  name_prefix           = "redis-replication-group-example"
+  number_cache_clusters = 2
+  node_type             = "cache.m5.large"
+  auth_token            = "1234567890asdfghjkl"
+
+  subnet_ids = data.aws_subnet_ids.replica.ids
+  vpc_id     = data.aws_vpc.replica.id
+
+  global_replication_group_id = aws_elasticache_global_replication_group.this.global_replication_group_id
+
+  providers = { aws = aws.replica }
+}

--- a/examples/redis-replication-group/main.tf
+++ b/examples/redis-replication-group/main.tf
@@ -54,7 +54,7 @@ resource "aws_elasticache_global_replication_group" "this" {
 module "redis_replica" {
   source = "../../"
 
-  name_prefix           = "redis-replication-group-example"
+  name_prefix           = "redis-replication-example"
   number_cache_clusters = 2
   node_type             = "cache.m5.large"
   auth_token            = "1234567890asdfghjkl"

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "aws_elasticache_replication_group" "redis" {
   snapshot_window            = var.snapshot_window
   snapshot_retention_limit   = var.snapshot_retention_limit
   final_snapshot_identifier  = var.final_snapshot_identifier
-  automatic_failover_enabled = var.global_replication_group_id == null && var.automatic_failover_enabled && var.number_cache_clusters > 1 ? true : false
+  automatic_failover_enabled = var.automatic_failover_enabled && var.number_cache_clusters > 1 ? true : false
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
   multi_az_enabled           = var.multi_az_enabled
 
@@ -131,4 +131,3 @@ resource "aws_security_group_rule" "redis_egress" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.redis.id
 }
-

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ resource "aws_elasticache_parameter_group" "redis" {
 }
 
 resource "aws_elasticache_subnet_group" "redis" {
-  name        = "${var.name_prefix}-redis-sg"
+  name        = var.global_replication_group_id == null ? "${var.name_prefix}-redis-sg" : "${var.name_prefix}-redis-sg-replica"
   subnet_ids  = var.subnet_ids
   description = var.description
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "aws_elasticache_replication_group" "redis" {
   engine = var.global_replication_group_id == null ? "redis" : null
 
-  parameter_group_name = var.global_replication_group_id == null ? aws_elasticache_parameter_group.redis[0].name : null
+  parameter_group_name = var.global_replication_group_id == null ? aws_elasticache_parameter_group.redis.name : null
   subnet_group_name    = aws_elasticache_subnet_group.redis.name
   security_group_ids   = concat(var.security_group_ids, [aws_security_group.redis.id])
 
@@ -58,8 +58,6 @@ resource "random_id" "redis_pg" {
 }
 
 resource "aws_elasticache_parameter_group" "redis" {
-  count = var.global_replication_group_id == null ? 1 : 0
-
   name        = "${var.name_prefix}-redis-${random_id.redis_pg.hex}"
   family      = var.family
   description = var.description

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,7 @@ output "elasticache_replication_group_member_clusters" {
 }
 
 output "elasticache_parameter_group_id" {
-  value       = aws_elasticache_parameter_group.redis.id
+  value       = var.global_replication_group_id == null ? aws_elasticache_parameter_group.redis[0].id : 0
   description = "The ElastiCache parameter group name."
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,7 @@ output "elasticache_replication_group_member_clusters" {
 }
 
 output "elasticache_parameter_group_id" {
-  value       = var.global_replication_group_id == null ? aws_elasticache_parameter_group.redis[0].id : 0
+  value       = aws_elasticache_parameter_group.redis.id
   description = "The ElastiCache parameter group name."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -180,3 +180,9 @@ variable "final_snapshot_identifier" {
   description = "The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made."
   default     = null
 }
+
+variable "global_replication_group_id" {
+  description = "The ID of the global replication group to which this replication group should belong."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
# Problem

I need to create Redis with a global replication group.
I can't do this because there is no `global_replication_group_group_id` value in this module.

Also, when we use `global_replication_group_id` we have to skip some variables becuase we don't need to provide them for the replication group.

# Solution

I created a PR with all changes for add `global_replication_group_id`.
I also spun up two Redis, one without ``global_replication_group_id` and second with that variable. Everything works.

Please, check the PR on your side and merge it.
