### PR TITLE
Upgrade module to be compatible with AWS Provider 4.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.50.0
+  rev: v1.64.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="2.2.0"></a>
+## [2.2.0] - 2021-08-11
+
+- Add support for global_replication_group_id ([#19](https://github.com/umotif-public/terraform-aws-elasticache-redis/issues/19))
+
+
+<a name="2.1.0"></a>
+## [2.1.0] - 2021-06-11
+
+- Update docs and use main branch as default ([#18](https://github.com/umotif-public/terraform-aws-elasticache-redis/issues/18))
+- Add tags support to all resources ([#17](https://github.com/umotif-public/terraform-aws-elasticache-redis/issues/17))
+
+
 <a name="2.0.0"></a>
 ## [2.0.0] - 2021-04-19
 
@@ -84,7 +97,9 @@ All notable changes to this project will be documented in this file.
 - Initial commit of docs
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/2.0.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/2.2.0...HEAD
+[2.2.0]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/2.1.0...2.2.0
+[2.1.0]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/1.5.0...2.0.0
 [1.5.0]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/1.4.0...1.5.0
 [1.4.0]: https://github.com/umotif-public/terraform-aws-elasticache-redis/compare/1.3.1...1.4.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/umotif-public/terraform-aws-elasticache-redis?style=social)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/umotif-public/terraform-aws-elasticache-redis)](https://github.com/umotif-public/terraform-aws-elasticache-redis/releases/latest)
 
 # terraform-aws-elasticache-redis
 
@@ -6,9 +6,10 @@ A Terraform module to create an AWS Redis ElastiCache cluster
 
 ## Terraform versions
 
-Terraform 0.14.5 and higher, pin module version to `~> v2.0`.
-For Terraform 0.12 to 0.14.4, pin module version to `~> v1.0`.
-Submit pull-requests to `main` branch.
+- For AWS Provider >= 4.0.0, pin module version to `~> v3.0`.
+- For Terraform 0.14.5 and higher *and* AWS Provider < 4.0.0, pin module version to `~> v2.0`.
+- For Terraform 0.12 to 0.14.4, pin module version to `~> v1.0`.
+- Submit pull-requests to `main` branch.
 
 ## Usage
 
@@ -57,27 +58,28 @@ module "redis" {
 
 ## Examples
 
-* [Redis Basic](https://github.com/umotif-public/terraform-aws-elasticache-redis/tree/master/examples/redis-basic)
-* [Redis Clustered Mode](https://github.com/umotif-public/terraform-aws-elasticache-redis/tree/master/examples/redis-clustered-mode)
+- [Redis Basic](https://github.com/umotif-public/terraform-aws-elasticache-redis/tree/main/examples/redis-basic)
+- [Redis Clustered Mode](https://github.com/umotif-public/terraform-aws-elasticache-redis/tree/main/examples/redis-clustered-mode)
+- [Redis Replication Group](https://github.com/umotif-public/terraform-aws-elasticache-redis/tree/main/examples/redis-replication-group)
 
 ## Authors
 
-Module managed by [Marcin Cuber](https://github.com/marcincuber) [linkedin](https://www.linkedin.com/in/marcincuber/).
+Module managed by [Abdul Wahid](https://github.com/Ohid25) ([LinkedIn](https://www.linkedin.com/in/abdul-wahid/))
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.11 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 
 ## Modules
@@ -105,8 +107,7 @@ No modules.
 | <a name="input_at_rest_encryption_enabled"></a> [at\_rest\_encryption\_enabled](#input\_at\_rest\_encryption\_enabled) | Whether to enable encryption at rest. | `bool` | `true` | no |
 | <a name="input_auth_token"></a> [auth\_token](#input\_auth\_token) | The password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true`. | `string` | `""` | no |
 | <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | n/a | `string` | `true` | no |
-| <a name="input_automatic_failover_enabled"></a> [automatic\_failover\_enabled](#input\_automatic\_failover\_enabled) | Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. | `bool` | `true` | no |
-| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important. | `list(string)` | `null` | no |
+| <a name="input_automatic_failover_enabled"></a> [automatic\_failover\_enabled](#input\_automatic\_failover\_enabled) | Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, number\_cache\_clusters must be greater than 1. Must be enabled for Redis (cluster mode enabled) replication groups. | `bool` | `true` | no |
 | <a name="input_cluster_mode_enabled"></a> [cluster\_mode\_enabled](#input\_cluster\_mode\_enabled) | Enable creation of a native redis cluster. | `bool` | `false` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the all resources. | `string` | `"Managed by Terraform"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The version number of the cache engine to be used for the cache clusters in this replication group. | `string` | `"5.0.6"` | no |
@@ -117,15 +118,16 @@ No modules.
 | <a name="input_ingress_self"></a> [ingress\_self](#input\_ingress\_self) | Specify whether the security group itself will be added as a source to the ingress rule. | `bool` | `false` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true` | `string` | `""` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | Specifies the weekly time range for when maintenance on the cache cluster is performed. | `string` | `""` | no |
-| <a name="input_multi_az_enabled"></a> [multi\_az\_enabled](#input\_multi\_az\_enabled) | Specifies whether to enable Multi-AZ Support for the replication group. If true, `automatic_failover_enabled` must also be enabled. Defaults to false. | `string` | `null` | no |
+| <a name="input_multi_az_enabled"></a> [multi\_az\_enabled](#input\_multi\_az\_enabled) | Specifies whether to enable Multi-AZ Support for the replication group. If true, `automatic_failover_enabled` must also be enabled. Defaults to false. | `string` | `false` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The replication group identifier. This parameter is stored as a lowercase string. | `string` | n/a | yes |
 | <a name="input_node_type"></a> [node\_type](#input\_node\_type) | The compute and memory capacity of the nodes in the node group. | `string` | n/a | yes |
 | <a name="input_notification_topic_arn"></a> [notification\_topic\_arn](#input\_notification\_topic\_arn) | An Amazon Resource Name (ARN) of an SNS topic to send ElastiCache notifications to. Example: `arn:aws:sns:us-east-1:012345678999:my_sns_topic` | `string` | `""` | no |
-| <a name="input_num_node_groups"></a> [num\_node\_groups](#input\_num\_node\_groups) | Required when `cluster_mode_enabled` is set to true. Specify the number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications. | `number` | `0` | no |
-| <a name="input_number_cache_clusters"></a> [number\_cache\_clusters](#input\_number\_cache\_clusters) | The number of cache clusters (primary and replicas) this replication group will have. | `number` | n/a | yes |
+| <a name="input_num_cache_clusters"></a> [num\_cache\_clusters](#input\_num\_cache\_clusters) | The number of cache clusters (primary and replicas) this replication group will have. If Multi-AZ is enabled, the value of this parameter must be at least 2. Updates will occur before other modifications. Conflicts with num\_node\_groups. | `number` | `1` | no |
+| <a name="input_num_node_groups"></a> [num\_node\_groups](#input\_num\_node\_groups) | Specify the number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications. | `number` | `0` | no |
 | <a name="input_parameter"></a> [parameter](#input\_parameter) | A list of Redis parameters to apply. Note that parameters may differ from one Redis family to another | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | <a name="input_port"></a> [port](#input\_port) | The port number on which each of the cache nodes will accept connections. | `number` | `6379` | no |
-| <a name="input_replicas_per_node_group"></a> [replicas\_per\_node\_group](#input\_replicas\_per\_node\_group) | Required when `cluster_mode_enabled` is set to true. Specify the number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will force a new resource. | `number` | `0` | no |
+| <a name="input_preferred_cache_cluster_azs"></a> [preferred\_cache\_cluster\_azs](#input\_preferred\_cache\_cluster\_azs) | A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important. | `list(string)` | `null` | no |
+| <a name="input_replicas_per_node_group"></a> [replicas\_per\_node\_group](#input\_replicas\_per\_node\_group) | Specify the number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will trigger an online resizing operation before other settings modifications. | `number` | `0` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of Security Groups. | `list(string)` | `[]` | no |
 | <a name="input_snapshot_retention_limit"></a> [snapshot\_retention\_limit](#input\_snapshot\_retention\_limit) | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | `number` | `30` | no |
 | <a name="input_snapshot_window"></a> [snapshot\_window](#input\_snapshot\_window) | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. | `string` | `""` | no |
@@ -164,9 +166,9 @@ See LICENSE for full details.
 
 ### Install dependencies
 
-* [`pre-commit`](https://pre-commit.com/#install)
-* [`terraform-docs`](https://github.com/segmentio/terraform-docs) required for `terraform_docs` hooks.
-* [`TFLint`](https://github.com/terraform-linters/tflint) required for `terraform_tflint` hook.
+- [`pre-commit`](https://pre-commit.com/#install)
+- [`terraform-docs`](https://github.com/segmentio/terraform-docs) required for `terraform_docs` hooks.
+- [`TFLint`](https://github.com/terraform-linters/tflint) required for `terraform_tflint` hook.
 
 #### MacOS
 

--- a/examples/redis-basic/main.tf
+++ b/examples/redis-basic/main.tf
@@ -12,8 +12,11 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 #####
 # Elasticache Redis
@@ -21,9 +24,9 @@ data "aws_subnet_ids" "all" {
 module "redis" {
   source = "../../"
 
-  name_prefix           = "redis-basic-example"
-  number_cache_clusters = 2
-  node_type             = "cache.t3.small"
+  name_prefix        = "redis-basic-example"
+  num_cache_clusters = 2
+  node_type          = "cache.t3.small"
 
   engine_version            = "6.x"
   port                      = 6379
@@ -43,7 +46,7 @@ module "redis" {
   family            = "redis6.x"
   description       = "Test elasticache redis."
 
-  subnet_ids = data.aws_subnet_ids.all.ids
+  subnet_ids = data.aws_subnets.all.ids
   vpc_id     = data.aws_vpc.default.id
 
   ingress_cidr_blocks = ["0.0.0.0/0"]

--- a/examples/redis-clustered-mode/main.tf
+++ b/examples/redis-clustered-mode/main.tf
@@ -9,8 +9,11 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "all" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 #####
@@ -19,9 +22,9 @@ data "aws_subnet_ids" "all" {
 module "redis" {
   source = "../../"
 
-  name_prefix           = "redis-clustered-example"
-  number_cache_clusters = 2
-  node_type             = "cache.t3.small"
+  name_prefix        = "redis-clustered-example"
+  num_cache_clusters = 2
+  node_type          = "cache.t3.small"
 
   cluster_mode_enabled    = true
   replicas_per_node_group = 1
@@ -43,7 +46,7 @@ module "redis" {
   family            = "redis6.x"
   description       = "Test elasticache redis."
 
-  subnet_ids = data.aws_subnet_ids.all.ids
+  subnet_ids = data.aws_subnets.all.ids
   vpc_id     = data.aws_vpc.default.id
 
   ingress_cidr_blocks = ["0.0.0.0/0"]

--- a/examples/redis-replication-group/main.tf
+++ b/examples/redis-replication-group/main.tf
@@ -21,12 +21,18 @@ data "aws_vpc" "replica" {
   provider = aws.replica
 }
 
-data "aws_subnet_ids" "main" {
-  vpc_id = data.aws_vpc.main.id
+data "aws_subnets" "main" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
 }
 
-data "aws_subnet_ids" "replica" {
-  vpc_id = data.aws_vpc.replica.id
+data "aws_subnets" "replica" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.replica.id]
+  }
 
   provider = aws.replica
 }
@@ -37,12 +43,12 @@ data "aws_subnet_ids" "replica" {
 module "redis_main" {
   source = "../../"
 
-  name_prefix           = "redis-replication-example"
-  number_cache_clusters = 2
-  node_type             = "cache.m5.large"
-  auth_token            = "1234567890asdfghjkl"
+  name_prefix        = "redis-example-main"
+  num_cache_clusters = 2
+  node_type          = "cache.m5.large"
+  auth_token         = "1234567890asdfghjkl"
 
-  subnet_ids = data.aws_subnet_ids.main.ids
+  subnet_ids = data.aws_subnets.main.ids
   vpc_id     = data.aws_vpc.main.id
 }
 
@@ -54,12 +60,12 @@ resource "aws_elasticache_global_replication_group" "this" {
 module "redis_replica" {
   source = "../../"
 
-  name_prefix           = "redis-replication-example"
-  number_cache_clusters = 2
-  node_type             = "cache.m5.large"
-  auth_token            = "1234567890asdfghjkl"
+  name_prefix        = "redis-example-replica"
+  num_cache_clusters = 2
+  node_type          = "cache.m5.large"
+  auth_token         = "1234567890asdfghjkl"
 
-  subnet_ids = data.aws_subnet_ids.replica.ids
+  subnet_ids = data.aws_subnets.replica.ids
   vpc_id     = data.aws_vpc.replica.id
 
   global_replication_group_id = aws_elasticache_global_replication_group.this.global_replication_group_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,12 +9,12 @@ output "elasticache_replication_group_id" {
 }
 
 output "elasticache_replication_group_primary_endpoint_address" {
-  value       = var.cluster_mode_enabled ? aws_elasticache_replication_group.redis.configuration_endpoint_address : aws_elasticache_replication_group.redis.primary_endpoint_address
+  value       = var.num_node_groups > 1 ? aws_elasticache_replication_group.redis.configuration_endpoint_address : aws_elasticache_replication_group.redis.primary_endpoint_address
   description = "The address of the endpoint for the primary node in the replication group."
 }
 
 output "elasticache_replication_group_reader_endpoint_address" {
-  value       = var.cluster_mode_enabled ? aws_elasticache_replication_group.redis.configuration_endpoint_address : aws_elasticache_replication_group.redis.reader_endpoint_address
+  value       = var.num_node_groups > 1 ? aws_elasticache_replication_group.redis.configuration_endpoint_address : aws_elasticache_replication_group.redis.reader_endpoint_address
   description = "The address of the endpoint for the reader node in the replication group."
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.14.5"
+  required_version = ">= 0.14.11"
 
   required_providers {
-    aws    = ">= 3.43"
+    aws    = ">= 4.0.0"
     random = ">= 3.1.0"
   }
 }


### PR DESCRIPTION
# Description

**BREAKING CHANGES**
1. Removed `cluster_mode` to use `replicas_per_node_group` and `num_node_groups` directly. 
2. `number_cache_clusters` changed to use `num_cache_clusters`
3. `availability_zones` changed to use `preferred_cache_cluster_azs`
4. `replication_group_description` changed to use `description`

You will still need to set `cluster_mode_enabled` to true if you want a Redis cluster.

These changes are based on the deprecation warnings that are received when trying to use this module with [provider >=4.0.0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group)