### PR TITLE
Fix outputs for endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to this project will be documented in this file.
 - Upgrade module to be compatible with AWS Provider 4.0.0 ([#21](https://github.com/umotif-public/terraform-aws-elasticache-redis/issues/21))
 
 
+<a name="3.0.0"></a>
+## [3.0.0] - 2022-03-09
+
+- Upgrade module to be compatible with AWS Provider 4.0.0 ([#21](https://github.com/umotif-public/terraform-aws-elasticache-redis/issues/21))
+
+
 <a name="2.2.0"></a>
 ## [2.2.0] - 2021-08-11
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ A Terraform module to create an AWS Redis ElastiCache cluster
 ```hcl
 module "redis" {
   source = "umotif-public/elasticache-redis/aws"
-  version = "~> v3.0"
+  version = "~> 3.0.0"
 
   name_prefix           = "core-example"
-  number_cache_clusters = 2
+  num_cache_cluster     = 2
   node_type             = "cache.t3.small"
 
   engine_version           = "6.x"

--- a/examples/redis-clustered-mode/main.tf
+++ b/examples/redis-clustered-mode/main.tf
@@ -28,7 +28,7 @@ module "redis" {
 
   cluster_mode_enabled    = true
   replicas_per_node_group = 1
-  num_node_groups         = 1
+  num_node_groups         = 2
 
   engine_version           = "6.x"
   port                     = 6379

--- a/examples/redis-clustered-mode/outputs.tf
+++ b/examples/redis-clustered-mode/outputs.tf
@@ -1,0 +1,7 @@
+output "primary_endpoint" {
+  value = module.redis.elasticache_replication_group_primary_endpoint_address
+}
+
+output "reader_endpoint" {
+  value = module.redis.elasticache_replication_group_reader_endpoint_address
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,12 +9,12 @@ output "elasticache_replication_group_id" {
 }
 
 output "elasticache_replication_group_primary_endpoint_address" {
-  value       = var.num_node_groups > 1 ? aws_elasticache_replication_group.redis.configuration_endpoint_address : aws_elasticache_replication_group.redis.primary_endpoint_address
+  value       = var.num_node_groups > 0 ? aws_elasticache_replication_group.redis.configuration_endpoint_address : aws_elasticache_replication_group.redis.primary_endpoint_address
   description = "The address of the endpoint for the primary node in the replication group."
 }
 
 output "elasticache_replication_group_reader_endpoint_address" {
-  value       = var.num_node_groups > 1 ? aws_elasticache_replication_group.redis.configuration_endpoint_address : aws_elasticache_replication_group.redis.reader_endpoint_address
+  value       = var.num_node_groups > 0 ? aws_elasticache_replication_group.redis.configuration_endpoint_address : aws_elasticache_replication_group.redis.reader_endpoint_address
   description = "The address of the endpoint for the reader node in the replication group."
 }
 


### PR DESCRIPTION
# Description

Set the value for output to > 0 to ensure primary and reader outputs work.

Related to issue #28. 