### PR TITLE
fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ module "redis" {
   version = "~> 3.0.0"
 
   name_prefix           = "core-example"
-  num_cache_cluster     = 2
+  num_cache_clusters    = 2
   node_type             = "cache.t3.small"
 
   engine_version           = "6.x"


### PR DESCRIPTION
change num_cache_cluster variable to num_cache_clusters, which is the actual variable name

# Description

The README example includes a reference to a variable "num_cache_cluster". The actual name of the variable is "num_cache_clusters". This change adds clarity to the example
