### PR TITLE
Add Data Tiering support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.2.0
+  rev: v4.3.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.71.0
+  rev: v1.73.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - Update README and basic example
 - Allow to configure for ingress from other SGs
 - Support Redis log delivery ([#26](https://github.com/umotif-public/terraform-aws-elasticache-redis/issues/26))
-
+- Support Data Tiering Feature for r6gd nodes
 
 <a name="3.0.0"></a>
 ## [3.0.0] - 2022-03-09

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ No modules.
 | <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | n/a | `string` | `true` | no |
 | <a name="input_automatic_failover_enabled"></a> [automatic\_failover\_enabled](#input\_automatic\_failover\_enabled) | Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, number\_cache\_clusters must be greater than 1. Must be enabled for Redis (cluster mode enabled) replication groups. | `bool` | `true` | no |
 | <a name="input_cluster_mode_enabled"></a> [cluster\_mode\_enabled](#input\_cluster\_mode\_enabled) | Enable creation of a native redis cluster. | `bool` | `false` | no |
+| <a name="input_data_tiering_enabled"></a> [data\_tiering\_enabled](#input\_data\_tiering\_enabled) | Enables data tiering. Data tiering is only supported for replication groups using the r6gd node type. This parameter must be set to true when using r6gd nodes. | `bool` | `false` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the all resources. | `string` | `"Managed by Terraform"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The version number of the cache engine to be used for the cache clusters in this replication group. | `string` | `"5.0.6"` | no |
 | <a name="input_family"></a> [family](#input\_family) | The family of the ElastiCache parameter group. | `string` | `"redis5.0"` | no |

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,8 @@ resource "aws_elasticache_replication_group" "redis" {
 
   description = var.description
 
+  data_tiering_enabled = var.data_tiering_enabled
+
   notification_topic_arn = var.notification_topic_arn
 
   replicas_per_node_group = var.cluster_mode_enabled ? var.replicas_per_node_group : null

--- a/variables.tf
+++ b/variables.tf
@@ -214,3 +214,9 @@ variable "allowed_security_groups" {
   description = "List of existing security groups that will be allowed ingress via the elaticache security group rules"
   default     = []
 }
+
+variable "data_tiering_enabled" {
+  type        = bool
+  default     = false
+  description = "Enables data tiering. Data tiering is only supported for replication groups using the r6gd node type. This parameter must be set to true when using r6gd nodes."
+}


### PR DESCRIPTION
# Description
Adding support for Data Tiering with r6gd nodes.

References:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#data_tiering_enabled

https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/data-tiering.html
