### PR TITLE
Add User Group ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ No modules.
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of VPC Subnet IDs for the cache subnet group. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources. | `map(string)` | `{}` | no |
 | <a name="input_transit_encryption_enabled"></a> [transit\_encryption\_enabled](#input\_transit\_encryption\_enabled) | Whether to enable encryption in transit. | `bool` | `true` | no |
+| <a name="input_user_group_ids"></a> [user\_group\_id](#input\_user\_group\_id) | User Group ID to associate with the replication group. | `list(string)` | n/a | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC Id to associate with Redis ElastiCache. | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ resource "aws_elasticache_replication_group" "redis" {
   replicas_per_node_group = var.cluster_mode_enabled ? var.replicas_per_node_group : null
   num_node_groups         = var.cluster_mode_enabled ? var.num_node_groups : null
 
+  user_group_ids = var.user_group_ids
   dynamic "log_delivery_configuration" {
     for_each = var.log_delivery_configuration
 

--- a/variables.tf
+++ b/variables.tf
@@ -220,3 +220,8 @@ variable "data_tiering_enabled" {
   default     = false
   description = "Enables data tiering. Data tiering is only supported for replication groups using the r6gd node type. This parameter must be set to true when using r6gd nodes."
 }
+variable "user_group_ids" {
+  type        = list(string)
+  default     = null
+  description = "User Group ID to associate with the replication group"
+}


### PR DESCRIPTION
Adding support for User Group ID. 

Ref: 
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#user_group_ids