### PR TITLE
Allow to skip sg egress rules creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -132,11 +132,13 @@ resource "aws_security_group_rule" "redis_ingress_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "redis_egress" {
+  count = length(var.egress_cidr_blocks) != 0 ? 1 : 0
+
   type              = "egress"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = var.egress_cidr_blocks
   security_group_id = aws_security_group.redis.id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "ingress_cidr_blocks" {
   default     = []
 }
 
+variable "egress_cidr_blocks" {
+  type        = list(string)
+  description = "List of Egress CIDR blocks."
+  default     = ["0.0.0.0/0"]
+}
+
 variable "ingress_self" {
   type        = bool
   description = "Specify whether the security group itself will be added as a source to the ingress rule."


### PR DESCRIPTION
# Description

By default, Redis doesn't need to have egress rules. Forcing to have egress rule open to the world flags a vulnerability by many security scanning tools.

https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/TroubleshootingConnections.html#Security_groups
