### PR TITLE
feat: Add support for `auth_token_update_strategy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ Module managed by [uMotif](https://github.com/umotif-public/)
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.12.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.27.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.3.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.27.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.3.2 |
 
 ## Modules
@@ -117,6 +117,7 @@ No modules.
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any modifications are applied immediately, or during the next maintenance window. | `bool` | `false` | no |
 | <a name="input_at_rest_encryption_enabled"></a> [at\_rest\_encryption\_enabled](#input\_at\_rest\_encryption\_enabled) | Whether to enable encryption at rest. | `bool` | `true` | no |
 | <a name="input_auth_token"></a> [auth\_token](#input\_auth\_token) | The password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true`. | `string` | `""` | no |
+| <a name="input_auth_token_update_strategy"></a> [auth\_token\_update\_strategy](#input\_auth\_token\_update\_strategy) | The strategy to use for applying updates to the auth\_token. Valid values are `ROTATE`, `SET` and `DELETE`. Defaults to `ROTATE`. Can be specified only if `transit_encryption_enabled = true` and `auth_token` is not empty. | `string` | `null` | no |
 | <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | n/a | `string` | `true` | no |
 | <a name="input_automatic_failover_enabled"></a> [automatic\_failover\_enabled](#input\_automatic\_failover\_enabled) | Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, number\_cache\_clusters must be greater than 1. Must be enabled for Redis (cluster mode enabled) replication groups. | `bool` | `true` | no |
 | <a name="input_cluster_mode_enabled"></a> [cluster\_mode\_enabled](#input\_cluster\_mode\_enabled) | Enable creation of a native redis cluster. | `bool` | `false` | no |

--- a/examples/redis-basic/main.tf
+++ b/examples/redis-basic/main.tf
@@ -44,7 +44,9 @@ module "redis" {
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true
+
   auth_token                 = "1234567890asdfghjkl"
+  auth_token_update_strategy = "ROTATE"
 
   apply_immediately = true
   family            = "redis7"

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ resource "aws_elasticache_replication_group" "redis" {
   at_rest_encryption_enabled  = var.global_replication_group_id == null ? var.at_rest_encryption_enabled : null
   transit_encryption_enabled  = var.global_replication_group_id == null ? var.transit_encryption_enabled : null
   auth_token                  = var.auth_token != "" ? var.auth_token : null
+  auth_token_update_strategy  = var.auth_token_update_strategy
   kms_key_id                  = var.kms_key_id
   global_replication_group_id = var.global_replication_group_id
 

--- a/variables.tf
+++ b/variables.tf
@@ -150,6 +150,12 @@ variable "auth_token" {
   default     = ""
 }
 
+variable "auth_token_update_strategy" {
+  type        = string
+  description = "The strategy to use for applying updates to the auth_token. Valid values are `ROTATE`, `SET` and `DELETE`. Defaults to `ROTATE`. Can be specified only if `transit_encryption_enabled = true` and `auth_token` is not empty."
+  default     = null
+}
+
 variable "kms_key_id" {
   type        = string
   description = "The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true`"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.12.0"
+      version = ">= 5.27.0"
     }
 
     random = {


### PR DESCRIPTION
# Description

Add support for a new parameter `auth_token_update_strategy` released in AWS Provider [v5.27.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.27.0).


