### PR TITLE
Allow in place upgrades redis engine version and family

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,7 @@ resource "aws_elasticache_parameter_group" "redis" {
 
   # Ignore changes to the description since it will try to recreate the resource
   lifecycle {
+    create_before_destroy = true
     ignore_changes = [
       description,
     ]


### PR DESCRIPTION
# Description
Solves issue 49.  version `3.5.0` removed the `create_before_delete` flag on `aws_elasticache_parameter_group`.
https://github.com/umotif-public/terraform-aws-elasticache-redis/issues/49

This results in a failure when attempting to upgrade the family and engine version of a cluster.