### PR TITLE
Restore Lifecycle setting for `parameter_group`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,7 @@ resource "aws_elasticache_parameter_group" "redis" {
 
   # Ignore changes to the description since it will try to recreate the resource
   lifecycle {
+    create_before_destroy = true
     ignore_changes = [
       description,
     ]


### PR DESCRIPTION
# Description

Re-introduces the lifecycle rule `create_before_destroy` on the `aws_elasticache_parameter_group`.  This should allow for the in place upgrade of elasticache when updating the `family` and `engine_version`
https://github.com/umotif-public/terraform-aws-elasticache-redis/issues/49

